### PR TITLE
ci: build binaries and upload them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: aminya/setup-scheme@master
+      - uses: actions/checkout@v3
+      - uses: guenchi/setup-scheme@master
         with:
           implementation: chicken
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on: 
+   push:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: aminya/setup-scheme@master
+        with:
+          implementation: chicken
+
+      - name: Build
+        run: |
+          chicken-install -s -from-list dependencies.txt
+          csc -s etc.scm -j etc
+          csc -s format.scm -j format
+          csc -static main.scm -o scheme-format
+
+      - name: Zip Binary File
+        run: |
+          7z a -tzip scheme-format-${{ runner.os }}.zip scheme-format*
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: scheme-format-${{ runner.os }}.zip


### PR DESCRIPTION
This automates building the binaries and uploading them. You can then download and upload the artifacts to a release tag.

I uploaded the binaries here in the meantime:
https://github.com/aminya/code-formatter/releases/tag/v2.2

An example run:
https://github.com/aminya/code-formatter/actions/runs/1732058879

![image](https://user-images.githubusercontent.com/16418197/150625719-bf28c8bd-91d7-4de2-9b41-aaaf8009f06e.png)

The binaries are available at the bottom of the page